### PR TITLE
Simplify GitHub Action setup

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,20 +12,17 @@ on:
     - main
 
 jobs:
-  build:
+  golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.23.x
+        go-version: stable
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
-
-    - name: Build source code
-      run: go build ./...
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.23.x
+          go-version: stable
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.23.x
+        go-version: stable
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3


### PR DESCRIPTION
Use `stable` as Go version.

Fix naming for linter job.

Remove unnecessary builds.
