### PR TITLE
Fix split filenames with zero-padding for reliable sorting

### DIFF
--- a/assets/examples/multi-doc.yml
+++ b/assets/examples/multi-doc.yml
@@ -1,0 +1,60 @@
+---
+index: 1
+name: document-one
+value: alpha
+---
+index: 2
+name: document-two
+value: bravo
+---
+index: 3
+name: document-three
+value: charlie
+---
+index: 4
+name: document-four
+value: delta
+---
+index: 5
+name: document-five
+value: echo
+---
+index: 6
+name: document-six
+value: foxtrot
+---
+index: 7
+name: document-seven
+value: golf
+---
+index: 8
+name: document-eight
+value: hotel
+---
+index: 9
+name: document-nine
+value: india
+---
+index: 10
+name: document-ten
+value: juliet
+---
+index: 11
+name: document-eleven
+value: kilo
+---
+index: 12
+name: document-twelve
+value: lima
+---
+index: 13
+name: document-thirteen
+value: mike
+---
+index: 14
+name: document-fourteen
+value: november
+---
+index: 15
+name: document-fifteen
+value: oscar

--- a/internal/cmd/cmd_suite_test.go
+++ b/internal/cmd/cmd_suite_test.go
@@ -34,6 +34,12 @@ import (
 	"github.com/homeport/yft/internal/cmd"
 )
 
+// indexOfSubstring returns the byte offset of the first occurrence of sub in s,
+// or -1 if not present. Used for ordering assertions in tests.
+func indexOfSubstring(s, sub string) int {
+	return strings.Index(s, sub)
+}
+
 func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "YAML File Tool command line tests")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -21,7 +21,10 @@
 package cmd_test
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -95,6 +98,71 @@ releases:
       version: 1.0.32
       sha1: 5ab3b7e685ca18a47d0b4a16d0e3b60832b0a393
 `))
+		})
+	})
+
+	Context("split command", func() {
+		It("should split a 15-document file into zero-padded filenames", func() {
+			tmpDir, err := os.MkdirTemp("", "yft-split-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			_, err = yft("split", "--directory", tmpDir, asset("examples", "multi-doc.yml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// With 15 documents, indices 0–14 need 2 digits: multi-doc-00.yml … multi-doc-14.yml
+			for i := 0; i < 15; i++ {
+				expected := filepath.Join(tmpDir, fmt.Sprintf("multi-doc-%02d.yml", i))
+				Expect(expected).To(BeAnExistingFile(),
+					"expected zero-padded split file %s to exist", expected)
+			}
+
+			// The unpadded single-digit names must NOT exist (for indices < 10,
+			// "%d" and "%02d" differ, so the unpadded file should never be created)
+			for i := 0; i < 10; i++ {
+				unexpected := filepath.Join(tmpDir, fmt.Sprintf("multi-doc-%d.yml", i))
+				Expect(unexpected).NotTo(BeAnExistingFile(),
+					"unpadded split file %s must not exist", unexpected)
+			}
+		})
+
+		It("should produce a join output that matches the original when files are sorted alphabetically", func() {
+			tmpDir, err := os.MkdirTemp("", "yft-split-join-test-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			_, err = yft("split", "--directory", tmpDir, asset("examples", "multi-doc.yml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			// Collect produced files and sort alphabetically (as a user / shell glob would)
+			entries, err := os.ReadDir(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			var splitFiles []string
+			for _, e := range entries {
+				if !e.IsDir() {
+					splitFiles = append(splitFiles, filepath.Join(tmpDir, e.Name()))
+				}
+			}
+			sort.Strings(splitFiles)
+			Expect(splitFiles).To(HaveLen(15))
+
+			joinArgs := append([]string{"join", "--name", "-"}, splitFiles...)
+			output, err := yft(joinArgs...)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify documents appear in ascending index order (1 through 15)
+			for i := 1; i <= 15; i++ {
+				Expect(output).To(ContainSubstring(fmt.Sprintf("index: %d", i)))
+			}
+
+			// Verify document i appears before document i+1 in the output
+			for i := 1; i < 15; i++ {
+				posA := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i))
+				posB := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i+1))
+				Expect(posA).To(BeNumerically("<", posB),
+					"document %d should appear before document %d in joined output", i, i+1)
+			}
 		})
 	})
 

--- a/internal/cmd/split.go
+++ b/internal/cmd/split.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gonvenience/ytbx"
@@ -61,13 +62,18 @@ var splitCmd = &cobra.Command{
 			extension := filepath.Ext(basename)
 			prefix := strings.TrimSuffix(basename, extension)
 
+			padding := len(strconv.Itoa(len(inputfile.Documents) - 1))
+			if padding < 2 {
+				padding = 2
+			}
+
 			for i, document := range inputfile.Documents {
 				// Special case, ignore empty documents
 				if len(document.Content) == 1 && document.Content[0].Tag == "!!null" {
 					continue
 				}
 
-				var filename string = fmt.Sprintf("%s-%d%s", prefix, i, extension)
+				filename := fmt.Sprintf("%s-%0*d%s", prefix, padding, i, extension)
 				if len(splitCmdSettings.directory) > 0 {
 					filename = filepath.Join(splitCmdSettings.directory, filename)
 				}


### PR DESCRIPTION
When splitting YAML files into more than 10 documents, the generated
filenames used simple numeric indexing (e.g., file-1.yml, file-10.yml),
which causes alphabetical sorting to fail. Files like file-10.yml would
sort before file-2.yml, breaking the join operation when files are
provided in sorted order.

Zero-pad filenames based on document count so that they sort correctly
alphabetically. For 15 documents, generate file-00.yml through file-14.yml
instead of file-0.yml through file-14.yml.

Add comprehensive tests to verify split creates zero-padded filenames
and that the split→sort→join roundtrip preserves document order.
