### PR TITLE
Fix bugs found during maintenance scan

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,5 +45,5 @@ homebrew_casks:
     name: GoReleaser Bot
     email: goreleaser@carlosbecker.com
   directory: Casks
-  homepage: "https://github.com/homeport/dyff"
+  homepage: "https://github.com/homeport/yft"
   description: "yft - YAML file tool"

--- a/internal/cmd/get.go
+++ b/internal/cmd/get.go
@@ -45,6 +45,10 @@ var getCmd = &cobra.Command{
 			return err
 		}
 
+		if len(inputfile.Documents) == 0 {
+			return fmt.Errorf("file %s contains no documents", location)
+		}
+
 		obj, err := ytbx.Grab(inputfile.Documents[0], pathString)
 		if err != nil {
 			return err

--- a/internal/cmd/restructure.go
+++ b/internal/cmd/restructure.go
@@ -98,10 +98,15 @@ Result:
 					return marshalErr
 				}
 
-				fmt.Fprint(writer, string(out))
+				if _, err := writer.Write(out); err != nil {
+					return err
+				}
 			}
 
-			writer.Flush()
+			if err = writer.Flush(); err != nil {
+				return err
+			}
+
 			err = os.WriteFile(location, buf.Bytes(), info.Mode())
 			if err != nil {
 				return err

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,6 +43,11 @@ var rootCmd = &cobra.Command{
 // Reset function is only used for testing
 func Reset() {
 	restructureCmdSettings.inplace = false
+	splitCmdSettings.directory = ""
+	joinCmdSettings.filename = ""
+	joinCmdSettings.ending = false
+	comparePathsByValue = false
+	ytbx.DisableRemainingKeySort = false
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/cmd/split.go
+++ b/internal/cmd/split.go
@@ -45,6 +45,12 @@ var splitCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, args []string) error {
+		if len(splitCmdSettings.directory) > 0 {
+			if info, err := os.Stat(splitCmdSettings.directory); err != nil || !info.IsDir() {
+				return fmt.Errorf("output directory %q does not exist or is not a directory", splitCmdSettings.directory)
+			}
+		}
+
 		for _, arg := range args {
 			location := filepath.Clean(arg)
 


### PR DESCRIPTION
- Correct Homebrew homepage URL (was pointing to dyff instead of yft)
- Guard against empty document slice before index access in get command
- Propagate write and flush errors in restructure in-place mode
- Reset all flag-backed globals in test helper to prevent state leakage
- Validate --directory exists before processing files in split command
