### PR TITLE
Make the YAML document start marker optional in split output

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -111,7 +111,7 @@ releases:
 			Expect(err).ToNot(HaveOccurred())
 
 			// With 15 documents, indices 0–14 need 2 digits: multi-doc-00.yml … multi-doc-14.yml
-			for i := 0; i < 15; i++ {
+			for i := range 15 {
 				expected := filepath.Join(tmpDir, fmt.Sprintf("multi-doc-%02d.yml", i))
 				Expect(expected).To(BeAnExistingFile(),
 					"expected zero-padded split file %s to exist", expected)
@@ -119,7 +119,7 @@ releases:
 
 			// The unpadded single-digit names must NOT exist (for indices < 10,
 			// "%d" and "%02d" differ, so the unpadded file should never be created)
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				unexpected := filepath.Join(tmpDir, fmt.Sprintf("multi-doc-%d.yml", i))
 				Expect(unexpected).NotTo(BeAnExistingFile(),
 					"unpadded split file %s must not exist", unexpected)
@@ -152,16 +152,46 @@ releases:
 			Expect(err).ToNot(HaveOccurred())
 
 			// Verify documents appear in ascending index order (1 through 15)
-			for i := 1; i <= 15; i++ {
-				Expect(output).To(ContainSubstring(fmt.Sprintf("index: %d", i)))
+			for i := range 15 {
+				Expect(output).To(ContainSubstring(fmt.Sprintf("index: %d", i+1)))
 			}
 
 			// Verify document i appears before document i+1 in the output
-			for i := 1; i < 15; i++ {
-				posA := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i))
-				posB := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i+1))
+			for i := range 14 {
+				posA := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i+1))
+				posB := indexOfSubstring(output, fmt.Sprintf("index: %d\n", i+2))
 				Expect(posA).To(BeNumerically("<", posB),
-					"document %d should appear before document %d in joined output", i, i+1)
+					"document %d should appear before document %d in joined output", i+1, i+2)
+			}
+		})
+
+		It("should not include a document start marker (---) by default", func() {
+			tmpDir, err := os.MkdirTemp("", "yft-split-no-marker-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			_, err = yft("split", "--directory", tmpDir, asset("examples", "multi-doc.yml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(filepath.Join(tmpDir, "multi-doc-00.yml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).NotTo(HavePrefix("---\n"),
+				"split output must not start with a document marker when --document-marker is not set")
+		})
+
+		It("should include a document start marker (---) when --document-marker flag is set", func() {
+			tmpDir, err := os.MkdirTemp("", "yft-split-with-marker-*")
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = os.RemoveAll(tmpDir) }()
+
+			_, err = yft("split", "--document-marker", "--directory", tmpDir, asset("examples", "multi-doc.yml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			for i := range 15 {
+				content, err := os.ReadFile(filepath.Join(tmpDir, fmt.Sprintf("multi-doc-%02d.yml", i)))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(content)).To(HavePrefix("---\n"),
+					"split output file %02d must start with a document marker when --document-marker is set", i)
 			}
 		})
 	})

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -44,6 +44,7 @@ var rootCmd = &cobra.Command{
 func Reset() {
 	restructureCmdSettings.inplace = false
 	splitCmdSettings.directory = ""
+	splitCmdSettings.documentMarker = false
 	joinCmdSettings.filename = ""
 	joinCmdSettings.ending = false
 	comparePathsByValue = false

--- a/internal/cmd/split.go
+++ b/internal/cmd/split.go
@@ -33,7 +33,8 @@ import (
 )
 
 var splitCmdSettings struct {
-	directory string
+	directory      string
+	documentMarker bool
 }
 
 // splitCmd represents the split command
@@ -89,7 +90,11 @@ var splitCmd = &cobra.Command{
 					return err
 				}
 
-				if err := os.WriteFile(filename, append([]byte("---\n"), bytes...), stat.Mode()); err != nil {
+				if splitCmdSettings.documentMarker {
+					bytes = append([]byte("---\n"), bytes...)
+				}
+
+				if err := os.WriteFile(filename, bytes, stat.Mode()); err != nil {
 					return err
 				}
 			}
@@ -103,4 +108,5 @@ func init() {
 	rootCmd.AddCommand(splitCmd)
 	splitCmd.Flags().SortFlags = false
 	splitCmd.Flags().StringVarP(&splitCmdSettings.directory, "directory", "d", "", "Write files to directory rather than current working directory")
+	splitCmd.Flags().BoolVar(&splitCmdSettings.documentMarker, "document-marker", false, "Prepend YAML document start marker (---) to each output file")
 }


### PR DESCRIPTION
Some consumers of the split command's output don't expect or want the
`---` document start marker prepended to each file, and for the
single-document-per-file case it carries no semantic meaning. Hardcoding
it forced users to post-process the files to strip it.

A new `--document-marker` flag lets callers opt in when they need the
marker; the default is to omit it.
